### PR TITLE
docs: clarify that spec_url must be publicly accessible

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -34,7 +34,7 @@ jobs:
 
 | Parameter | What it does |
 |-----------|-------------|
-| `spec_url` | Link to your spec (Google Doc, Notion, etc.) |
+| `spec_url` | Link to your spec (Google Doc, Notion, etc.). **Must be publicly accessible** (or "anyone with the link can view"). Without access to spec, review is impossible. |
 | `review_scope` | `full` (default), `security`, or `spec-compliance` |
 | `telegram_contact` | Your Telegram — we'll message you when review is ready |
 


### PR DESCRIPTION
## Summary
- Added note that `spec_url` must be publicly accessible ("anyone with the link can view")
- This is the most common setup mistake: client adds a private Google Doc link, reviewer can't open it, review fails silently

## Test plan
- [ ] Open SKILL.md, read Step 2 parameter table
- [ ] `spec_url` row should clearly state the document must be public

Generated with [Claude Code](https://claude.com/claude-code)